### PR TITLE
Fixed Bootstrap CSS, added conditional .row

### DIFF
--- a/src/callout.html
+++ b/src/callout.html
@@ -1,14 +1,14 @@
 <div class="clearfix bs-callout bs-callout-{{form.style || 'default'}} schema-form-callout" ng-disabled="form.readonly">
-  <div ng-class="{'col-xs-6': form.inline }">
-    <h4 ng-show="showTitle()" ng-bind="form.title"></h4>
-    <p class="description" ng-show="form.description"
-       ng-bind-html="form.description"></p>
-  </div>
-
-  <div ng-class="{'col-xs-6': form.inline, 'schema-form-callout-fields': !form.inline  }">
-    <div ng-class="{'pull-right': form.inline}">
-      <sf-decorator ng-repeat="item in form.items" form="item"></sf-decorator>
+  <div ng-class="{'row': form.inline}">
+    <div ng-class="{'col-xs-6': form.inline }">
+      <h4 ng-show="showTitle()" ng-bind="form.title"></h4>
+      <p class="description" ng-show="form.description"
+         ng-bind-html="form.description"></p>
+    </div>
+    <div ng-class="{'col-xs-6': form.inline, 'schema-form-callout-fields': !form.inline  }">
+      <div ng-class="{'pull-right': form.inline}">
+        <sf-decorator ng-repeat="item in form.items" form="item"></sf-decorator>
+      </div>
     </div>
   </div>
-
 </div>


### PR DESCRIPTION
Fixed incorrect use of Bootstrap CSS. Adds a container div which can act as a .row when using .col-\* (for the inline forms).
