### PR TITLE
Callouts use form-inline internally

### DIFF
--- a/src/callout.html
+++ b/src/callout.html
@@ -1,11 +1,11 @@
 <div class="clearfix bs-callout bs-callout-{{form.style || 'default'}} schema-form-callout" ng-disabled="form.readonly">
-  <div ng-class="{'row': form.inline}">
+  <div ng-class="{'row': form.inline, 'form-inline': form.inline}">
     <div ng-class="{'col-xs-6': form.inline }">
       <h4 ng-show="showTitle()" ng-bind="form.title"></h4>
       <p class="description" ng-show="form.description"
          ng-bind-html="form.description"></p>
     </div>
-    <div ng-class="{'col-xs-6': form.inline, 'schema-form-callout-fields': !form.inline  }">
+    <div ng-class="{'col-xs-6': form.inline, 'schema-form-callout-fields': !form.inline}">
       <div ng-class="{'pull-right': form.inline}">
         <sf-decorator ng-repeat="item in form.items" form="item"></sf-decorator>
       </div>


### PR DESCRIPTION
I think this change make sense, the settings indicate that this should behave like an inline form
